### PR TITLE
#22 search Schema 작성

### DIFF
--- a/app/schemas/artist.py
+++ b/app/schemas/artist.py
@@ -7,11 +7,11 @@ class ArtistBase(BaseModel):
     name: Optional[str] = None
     introduction: Optional[str] = None
     profile_image: Optional[HttpUrl] = None
-    follow: Optional[int] = None
+    follow: Optional[int] = 0
 
 
 class ArtistResultBase(ArtistBase):
     id: str
     name: str
     profile_image: HttpUrl
-    follow: int
+    follow: int = 0

--- a/app/schemas/artist.py
+++ b/app/schemas/artist.py
@@ -10,7 +10,7 @@ class ArtistBase(BaseModel):
     follow: Optional[int] = None
 
 
-class ArtistOutput(ArtistBase):
+class ArtistResultBase(ArtistBase):
     id: str
     name: str
     profile_image: HttpUrl

--- a/app/schemas/playlist.py
+++ b/app/schemas/playlist.py
@@ -1,7 +1,7 @@
 from typing import Optional, List
 from pydantic import BaseModel, HttpUrl
 
-from app.schemas.song import SongOutput
+from app.schemas.song import SongBaseResult
 
 
 class PlaylistBase(BaseModel):
@@ -10,6 +10,14 @@ class PlaylistBase(BaseModel):
     owner_id: Optional[int] = None
     profile_image: Optional[HttpUrl] = None
     like: Optional[int] = 0
+
+
+class PlaylistBaseResult(PlaylistBase):
+    id: int
+    title: str
+    owner_id: int
+    profile_image: HttpUrl
+    like: int = 0
 
 
 class PlaylistCreate(PlaylistBase):
@@ -22,9 +30,9 @@ class PlaylistDetail(PlaylistBase):
     title: str
     owner_id: int
     profile_image: HttpUrl
-    like: int
-    songs: Optional[List[SongOutput]] = None
+    like: int = 0
+    songs: Optional[List[SongBaseResult]] = None
 
 
 class PlaylistList(PlaylistBase):
-    results: Optional[List[PlaylistBase]]
+    results: Optional[List[PlaylistBaseResult]]

--- a/app/schemas/search.py
+++ b/app/schemas/search.py
@@ -1,0 +1,18 @@
+from typing import Optional, List
+from pydantic import BaseModel
+
+from app.schemas.playlist import PlaylistBaseResult
+from app.schemas.artist import ArtistResultBase
+from app.schemas.song import SongBaseResult
+
+
+class SearchPlaylist(BaseModel):
+    results: Optional[List[PlaylistBaseResult]]
+
+
+class SearchArtist(BaseModel):
+    results: Optional[List[ArtistResultBase]]
+
+
+class SearchSong(BaseModel):
+    results: Optional[List[SongBaseResult]]

--- a/app/schemas/song.py
+++ b/app/schemas/song.py
@@ -8,6 +8,7 @@ class SongBase(BaseModel):
     artist_id: Optional[int] = None
     description: Optional[str] = None
     play: Optional[int] = None
+    like: Optional[int] = None
     link: Optional[HttpUrl] = None
     profile_image: Optional[HttpUrl] = None
 
@@ -16,7 +17,8 @@ class SongBaseResult(SongBase):
     id: int
     title: str
     artist_id: int
-    play: int
+    play: int = 0
+    like: int = 0
     profile_image: HttpUrl
 
 

--- a/app/schemas/song.py
+++ b/app/schemas/song.py
@@ -12,7 +12,7 @@ class SongBase(BaseModel):
     profile_image: Optional[HttpUrl] = None
 
 
-class SongOutput(SongBase):
+class SongBaseResult(SongBase):
     id: int
     title: str
     artist_id: int
@@ -21,4 +21,4 @@ class SongOutput(SongBase):
 
 
 class SongList(SongBase):
-    results: Optional[List[SongOutput]] = None
+    results: Optional[List[SongBaseResult]] = None


### PR DESCRIPTION
closes #22 
- 기존 `*Output`으로 작명된 클래스이름을 `*BaseResult`로 변경
- `app.schemas.playlist`
   - `PlaylistBaseResult`
- `app.schemas.search`
   - `SearchPlaylist`
   - `SearchArtist`
   - `SearchSong`